### PR TITLE
Add back GoPro.Camera.getMedia, it was missing from this repo

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -332,6 +332,28 @@ GoPro.Camera.prototype.listMedia = function () {
     });
 };
 
+
+GoPro.Camera.prototype.getMedia = function(url, path) {
+    var self = this;
+    var promise = when.promise(function (resolve, reject, notify) {
+        var name = url.split("/");
+        name = path+'/'+name[name.length-1];
+        console.log("GET", url);
+        console.log('TO', name);
+        var out = fs.createWriteStream(name);
+        out.on('error' ,function(err){ console.log("[stream error]", err); reject(err); });
+        out.on('end'   ,function()   { console.log("[stream end]"       ); });
+        out.on('finish',function()   { console.log("[stream finish]"    ); });
+        out.on('close' ,function()   { console.log("[stream close]"     ); resolve(name)});
+
+        var req = request(url);
+        req.on('error', function(err){ console.log("[request error]", err); reject(err); });
+        req.pipe(out);
+    });
+    return (promise);
+
+};
+
 GoPro.Camera.prototype.deleteAll = function () {
     var self = this;
     return this._retryPromise(function (resolve, reject) {


### PR DESCRIPTION
Not sure why, but when I `npm install goproh4` I get the super helpful Camera method `getMedia`, which I use all the time. When I `npm install <github repo url>` from `master` there's no `getMedia` method. This PR adds it back it, its super helpful.